### PR TITLE
fix bnet user messaging

### DIFF
--- a/Sources/ToolBox.lua
+++ b/Sources/ToolBox.lua
@@ -109,7 +109,10 @@ function WIM.GetNameAndServer(user)
 		realm = string.gsub(realm, "[A-Z]", " %1")
 		realm = string.gsub(realm, "' ", "'")
 		realm = string.gsub(realm, "^[a-z]", string.upper)
+	else
+		name = user
 	end
+	
 	return name, realm
 end
 


### PR DESCRIPTION
When trying to send a message to a battle.net friend I get the following:

**Issue**
Message: Interface/AddOns/WIM/Sources/ToolBox.lua:119: attempt to concatenate local 'name' (a table value)
Time: Tue Dec  6 14:14:43 2022
Count: 1
Stack: Interface/AddOns/WIM/Sources/ToolBox.lua:119: attempt to concatenate local 'name' (a table value)
[string "=[C]"]: ?
[string "@Interface/AddOns/WIM/Sources/ToolBox.lua"]:119: in function `GetReadableName'
[string "@Interface/AddOns/WIM/Sources/WindowHandler.lua"]:1356: in function <Interface/AddOns/WIM/Sources/WindowHandler.lua:1329>
[string "@Interface/AddOns/WIM/Sources/WindowHandler.lua"]:1440: in function <Interface/AddOns/WIM/Sources/WindowHandler.lua:1389>
[string "=(tail call)"]: ?
[string "@Interface/AddOns/WIM/Modules/WhisperEngine.lua"]:200: in function <Interface/AddOns/WIM/Modules/WhisperEngine.lua:179>
[string "@Interface/AddOns/WIM/Modules/WhisperEngine.lua"]:716: in function <Interface/AddOns/WIM/Modules/WhisperEngine.lua:693>
[string "=[C]"]: in function `ChatFrame_OpenChat'
[string "@Interface/FrameXML/ChatFrame.lua"]:4156: in function <Interface/FrameXML/ChatFrame.lua:4151>
[string "=[C]"]: in function `ChatFrame_SendBNetTell'
[string "@Interface/FrameXML/FriendsFrame.lua"]:984: in function <Interface/FrameXML/FriendsFrame.lua:976>

------------------------------------------------

This PR fixes that issue.