### PR TITLE
Support for item links with a quality icon

### DIFF
--- a/Modules/WhisperEngine.lua
+++ b/Modules/WhisperEngine.lua
@@ -241,7 +241,7 @@ function SendSplitMessage(PRIORITY, HEADER, theMsg, CHANNEL, EXTRA, to)
 	theMsg = string.gsub(theMsg, "|h|H", "|h |H");
 
 	-- parse out links as to not split them incorrectly.
-	theMsg, results = string.gsub(theMsg, "(|H[^|]+|h[^|]+|h)", function(theLink)
+	theMsg, results = string.gsub(theMsg, "(|H[^|]+|h.-|h|r)", function(theLink)
 		table.insert(splitMessageLinks, theLink);
 		return "\001\002"..paddString(#splitMessageLinks, "0", string.len(theLink)-4).."\003\004";
 	end);


### PR DESCRIPTION
I've also added the "|r" at the end of the pattern because it seems to be part of the item links that WoW generates.

Related to https://github.com/Legacy-of-Sylvanaar/wow-instant-messenger/issues/28.

## Additional info

Example of item link with quality icon: `|Hitem:193223::::::::70:252:::::::::|h[Lustrous Scaled Hide |A:Professions-ChatIcon-Quality-Tier2:17:23::1|a]|h|r`.

Documentation for the `-` pattern feature: https://www.lua.org/manual/5.1/manual.html#5.4.1 under "Pattern Item".