### PR TITLE
Fixed location button left and right click

### DIFF
--- a/Modules/ShortcutBar.lua
+++ b/Modules/ShortcutBar.lua
@@ -305,10 +305,10 @@ RegisterShortcut("location", L["Player Location"], {
 		OnClick = function(self, button)
 			libs.DropDownMenu.CloseDropDownMenus();
 			if(button == "LeftButton") then
-	      local currentSelf = self;
-	      self.parentWindow:SendWho(function()
-	        buttons[currentSelf.index].scripts.OnEnter(currentSelf);
-	        end)
+				local currentSelf = self;
+				self.parentWindow:SendWho(function()
+					buttons[currentSelf.index].scripts.OnEnter(currentSelf);
+					end)
 			else
 				WIM.MENU_ARMORY_USER = self.parentWindow.theUser;
 				WIM.MENU_ARMORY_REALM = env.realm;

--- a/Modules/ShortcutBar.lua
+++ b/Modules/ShortcutBar.lua
@@ -305,7 +305,10 @@ RegisterShortcut("location", L["Player Location"], {
 		OnClick = function(self, button)
 			libs.DropDownMenu.CloseDropDownMenus();
 			if(button == "LeftButton") then
-				self.parentWindow:SendWho();
+	      local currentSelf = self;
+	      self.parentWindow:SendWho(function()
+	        buttons[currentSelf.index].scripts.OnEnter(currentSelf);
+	        end)
 			else
 				WIM.MENU_ARMORY_USER = self.parentWindow.theUser;
 				WIM.MENU_ARMORY_REALM = env.realm;
@@ -318,6 +321,7 @@ RegisterShortcut("location", L["Player Location"], {
 		end,
 		OnEnter = function(self)
 			local location = self.parentWindow.location ~= "" and self.parentWindow.location or L["Unknown"];
+			local guild = self.parentWindow.guild ~= "" and self.parentWindow.guild or L["Unknown"];
 			local tbl = self.parentWindow.w2w;
 			if(not tbl or not tbl.services) then
 				_G.GameTooltip:SetOwner(self, "ANCHOR_RIGHT");

--- a/Modules/URLHandler.lua
+++ b/Modules/URLHandler.lua
@@ -21,11 +21,6 @@ local URL = CreateModule("URLHandler", true);
 
 armoryLinks = {
     {
-        title = "WoW Armory",
-		--https://worldofwarcraft.blizzard.com/en-us/character/us/moon-guard/zincarla
-		url = "https://worldofwarcraft.blizzard.com/{armeu/armus}/character/{eu/us}/{realm-}/{user}"
-    },
-    {
 		title = "Wowhead Profiler",
 		url = "http://www.wowhead.com/profile={eu/us}.{realm-}.{user}",
     },
@@ -33,27 +28,18 @@ armoryLinks = {
         title = "WoWProgress",
         url = "http://www.wowprogress.com/character/{eu/us}/{realm}/{user}"
     },
-    {
-        title = "AskMrRobot",
-        --url = "http://www.askmrrobot.com/wow/player/{eu/us}/{realm}/{user}"
-				url = "https://www.askmrrobot.com/optimizer#{eu/us}/{realm}/{user}"
-    },
-    {
-        title = "Warcraftlogs",
-        url = "https://www.warcraftlogs.com/character/{eu/us}/{realm}/{user}"
-    },
 		{
         title = "Raider io",
         url = "https://raider.io/characters/{eu/us}/{realm}/{user}"
     },
     {
-        title = "WoWTrack",
-        url = "https://wowtrack.org/characters/{eu/us}/{realm}/{user}"
+        title = "Warcraftlogs Retail",
+        url = "https://www.warcraftlogs.com/character/{eu/us}/{realm}/{user}"
     },
-		{
-				title = "Character Name",
-				url = "{user}"
-		}
+    {
+        title = "Warcraftlogs SoD",
+        url = "https://vanilla.warcraftlogs.com/character/{eu/us}/{realm}/{user}"
+    },
 };
 
 -- patterns created by Sylvanaar & used in Prat
@@ -258,7 +244,8 @@ local function MENU_ARMORY_CLICKED(self)
     local link = self.value;
     link = link:gsub("{eu/www}", eu_www);
 	realm = string.gsub(realm, "'", "")
-    link = link:gsub("{realm}", realm);
+    --link = link:gsub("{realm}", realm);
+    link = link:gsub("{realm}", (string.gsub(realm,"  ","-")));
     link = link:gsub("{realm%-}", (string.gsub(realm," ","-")));
     link = link:gsub("{user}", user);
     link = link:gsub("{eu/us}", eu_us);

--- a/Modules/URLHandler.lua
+++ b/Modules/URLHandler.lua
@@ -33,11 +33,11 @@ armoryLinks = {
         url = "https://raider.io/characters/{eu/us}/{realm}/{user}"
     },
     {
-        title = "Warcraftlogs Retail",
+        title = "Warcraft Logs",
         url = "https://www.warcraftlogs.com/character/{eu/us}/{realm}/{user}"
     },
     {
-        title = "Warcraftlogs SoD",
+        title = "Warcraft Logs Vanilla",
         url = "https://vanilla.warcraftlogs.com/character/{eu/us}/{realm}/{user}"
     },
 };

--- a/Sources/WindowHandler.lua
+++ b/Sources/WindowHandler.lua
@@ -1133,12 +1133,15 @@ local function instantiateWindow(obj)
 						            if wCallback then
 						                wCallback();
 						            end
+						            _G.C_FriendList.SetWhoToUi(false);
+						            -- close who frame
+						            _G.FriendsFrameCloseButton:Click();
 					            end
 					        end
 					        self:UnregisterEvent("WHO_LIST_UPDATE");
 					    end
 					end
-					_G.C_FriendList.SetWhoToUi(1);
+					_G.C_FriendList.SetWhoToUi(true);
 					local wFrame = CreateFrame("Frame");
 					wFrame:RegisterEvent("WHO_LIST_UPDATE");
 				    wFrame:SetScript("OnEvent", eventHandlerWho);

--- a/Sources/WindowHandler.lua
+++ b/Sources/WindowHandler.lua
@@ -1114,6 +1114,34 @@ local function instantiateWindow(obj)
 						end
 					end
         		end
+        		if( obj.location == "" ) then
+					local function eventHandlerWho(self, event, ...)
+						-- CODE NEVER REACHED :<<
+					    if event == "WHO_LIST_UPDATE" then
+					        local numResults = _G.C_FriendList.GetNumWhoResults()
+					        for i = 1, numResults do
+					            local info = _G.C_FriendList.GetWhoInfo(i)
+					            if( info.fullName == self.thUser ) then
+									_G.WhoCallback({
+										Name = info.fullName or "",
+										Online = true,
+										Guild = info.guild or "",
+										Class = info.classStr or "",
+										Level = info.level or "",
+										Race = info.raceStr or "",
+										Zone = info.area or "",
+									});
+					            end
+					        end
+					        self:UnregisterEvent("WHO_LIST_UPDATE")
+					    end
+					end
+					local wFrame = CreateFrame("Frame")
+					wFrame:RegisterEvent("WHO_LIST_UPDATE")
+				    wFrame:SetScript("OnEvent", eventHandlerWho)
+				    wFrame.thUser = self.theUser
+				    _G.C_FriendList.SendWho("n-"..self.theUser)
+				end
         end
     end
 

--- a/Sources/WindowHandler.lua
+++ b/Sources/WindowHandler.lua
@@ -1012,7 +1012,7 @@ local function instantiateWindow(obj)
         end
     end
 
-    obj.SendWho = function(self)
+    obj.SendWho = function(self,wCallback)
         if(self.type ~= "whisper") then
                 return;
         end
@@ -1116,31 +1116,35 @@ local function instantiateWindow(obj)
         		end
         		if( obj.location == "" ) then
 					local function eventHandlerWho(self, event, ...)
-						-- CODE NEVER REACHED :<<
 					    if event == "WHO_LIST_UPDATE" then
-					        local numResults = _G.C_FriendList.GetNumWhoResults()
+					        local numResults = _G.C_FriendList.GetNumWhoResults();
 					        for i = 1, numResults do
-					            local info = _G.C_FriendList.GetWhoInfo(i)
+					            local info = _G.C_FriendList.GetWhoInfo(i);
 					            if( info.fullName == self.thUser ) then
-									_G.WhoCallback({
+									self.WCallback({
 										Name = info.fullName or "",
 										Online = true,
-										Guild = info.guild or "",
+										Guild = info.fullGuildName or "",
 										Class = info.classStr or "",
 										Level = info.level or "",
 										Race = info.raceStr or "",
 										Zone = info.area or "",
 									});
+						            if wCallback then
+						                wCallback();
+						            end
 					            end
 					        end
-					        self:UnregisterEvent("WHO_LIST_UPDATE")
+					        self:UnregisterEvent("WHO_LIST_UPDATE");
 					    end
 					end
-					local wFrame = CreateFrame("Frame")
-					wFrame:RegisterEvent("WHO_LIST_UPDATE")
-				    wFrame:SetScript("OnEvent", eventHandlerWho)
-				    wFrame.thUser = self.theUser
-				    _G.C_FriendList.SendWho("n-"..self.theUser)
+					_G.C_FriendList.SetWhoToUi(1);
+					local wFrame = CreateFrame("Frame");
+					wFrame:RegisterEvent("WHO_LIST_UPDATE");
+				    wFrame:SetScript("OnEvent", eventHandlerWho);
+				    wFrame.thUser = self.theUser;
+				    wFrame.WCallback = self.WhoCallback;
+				    _G.C_FriendList.SendWho("n-"..self.theUser);
 				end
         end
     end

--- a/WIM.toc
+++ b/WIM.toc
@@ -1,5 +1,5 @@
 ## Interface: 100205
-## Interface-Classic: 11404
+## Interface-Classic: 11501
 ## Interface-BCC: 20504
 ## Interface-Wrath: 30403
 


### PR DESCRIPTION
While left click didn't update the location of the player, it is doing the update now (incl. further player information: class, level, guild etc.) via who list.
For the right click the list of links is updated, incl. a warcraft logs link for vanilla (SoD).

See #69