### PR TITLE
Fixing the whisper length check.

### DIFF
--- a/Modules/WhisperEngine.lua
+++ b/Modules/WhisperEngine.lua
@@ -330,19 +330,10 @@ RegisterWidgetTrigger("msg_box", "whisper", "OnEnterPressed", function(self)
         local obj = self:GetParent();
         local msg = PreSendFilterText(self:GetText());
 		local messageLength = obj.isBN and 800 or 255;
-        local msgCount = math.ceil(string.len(msg)/messageLength);
-        if(msgCount == 1) then
-            Windows[safeName(obj.theUser)].msgSent = true;
-			if(obj.isBN) then
-				(_G.C_BattleNet and _G.C_BattleNet.SendWhisper or _G.BNSendWhisper)(obj.bn.id, msg);
-			else
-				_G.SendChatMessage(msg, "WHISPER", nil, obj.theUser);
-				-- _G.ChatThrottleLib:SendChatMessage("ALERT", "WIM", msg, "WHISPER", nil, obj.theUser);
-			end
-        elseif(msgCount > 1) then
-            Windows[safeName(obj.theUser)].msgSent = true;
-            SendSplitMessage("ALERT", "WIM", msg, "WHISPER", nil, obj.theUser);
-        end
+
+		Windows[safeName(obj.theUser)].msgSent = true;
+		SendSplitMessage("ALERT", "WIM", msg, "WHISPER", nil, obj.theUser);
+
         self:SetText("");
     end);
 


### PR DESCRIPTION
Fixing the whisper length check. While the SendSplitMessage correctly checks hyperlinks length, the Enter press callback uses plain string.len, unnecessarily truncating messages with links. This PR removes all the checks in the callback and lets SendSplitMessage to do its job.