### PR TITLE
Minor Update to WindowHandler.lua

### DIFF
--- a/Sources/WindowHandler.lua
+++ b/Sources/WindowHandler.lua
@@ -1102,6 +1102,9 @@ local function instantiateWindow(obj)
 					self.bn.hasFocus = hasFocus;
 					self.bn.id = id;
 					-- self.widgets.from:SetText(self.theUser.." - "..toonName);
+					if (toonName and toonName ~= "") then
+                        self.widgets.from:SetText(GetReadableName(self.theUser).." ("..toonName..")");
+                    end
 					self:UpdateIcon();
 					if (client == _G.BNET_CLIENT_WOW) then
 						self:UpdateCharDetails();


### PR DESCRIPTION
Updated to add Current Toon Name to Battle.net Friends' Window Titles.

I don't always remember who my Battle.net Friends are... this way if they message me I have something tying them back to the characters I met them on. (=

Original:

<img width="454" height="46" alt="image" src="https://github.com/user-attachments/assets/571433ff-14dc-43fa-b9d0-cd2ffc3b5a7f" />

Udpated:

<img width="456" height="45" alt="image" src="https://github.com/user-attachments/assets/941036e6-802c-4494-83e3-e29e5b10de7b" />

Request from a friend, Thule / Plateglass. Smart suggestion.
