### PR TITLE
Update WIM.toc

### DIFF
--- a/WIM.toc
+++ b/WIM.toc
@@ -1,6 +1,6 @@
 ## Interface: 110207, 120000
 ## Interface-Classic: 11508
-## Interface-BCC: 20504
+## Interface-BCC: 20505
 ## Interface-Wrath: 30405
 ## Interface-Cata: 40402
 ## Interface-Mists: 50503


### PR DESCRIPTION
<img width="964" height="71" alt="image" src="https://github.com/user-attachments/assets/7d9b7988-580b-41fd-89de-101e20337276" />

2.5.5 is the correct version for TBC Anniversary. (Sorry if I already opened a PR for this, kind of forgot if I did or didn't. Ha.)