### PR TITLE
Refactor target assignment in whisper handling

### DIFF
--- a/Modules/WhisperEngine.lua
+++ b/Modules/WhisperEngine.lua
@@ -846,7 +846,7 @@ local function editBoxUpdateHeader(self, internalCall)
 	prevChatType, prevTellTarget = chatType, tellTarget;
 
 	if (chatType == "WHISPER" or chatType == "BN_WHISPER") then
-		local target = _G.Ambiguate(tellTarget, "none");
+		local target = tellTarget and _G.Ambiguate(tellTarget, "none");
 
 		-- handle the whisper interception
 		if (not InChatMessagingLockdown() and target and db and db.enabled) then


### PR DESCRIPTION
Fix for a lua error in Classic.

38x bad argument #1 to '?' (Usage: local result = Ambiguate(fullName, context))
[WIM/Modules/WhisperEngine.lua]:849: in function <WIM/Modules/WhisperEngine.lua:834>
[C]: in function 'UpdateHeader'
[Blizzard_ChatFrameBase/Shared/ChatFrameEditBox.lua]:583: in function 'ResetChatType'
[Blizzard_ChatFrameBase/Shared/ChatFrameEditBox.lua]:373: in function <...s/Blizzard_ChatFrameBase/Shared/ChatFrameEditBox.lua:371>
[C]: in function 'Show'
[Blizzard_ChatFrameBase/Shared/ChatFrameUtil.lua]:457: in function <...dOns/Blizzard_ChatFrameBase/Shared/ChatFrameUtil.lua:441>
[C]: ?
[C]: in function 'ActivateChat'
[Blizzard_ChatFrameBase/Shared/ChatFrameUtil.lua]:399: in function 'OpenChat'
[Blizzard_ChatFrameBase/Shared/ChatFrameUtil.lua]:301: in function 'SendTellWithMessage'
[Blizzard_ChatFrameBase/Shared/ChatFrameUtil.lua]:310: in function 'SendTell'
[Blizzard_UnitPopupShared/UnitPopupSharedButtonMixins.lua]:449: in function <...zard_UnitPopupShared/UnitPopupSharedButtonMixins.lua:431>
[tail call]: ?
[tail call]: ?
[C]: in function 'securecallfunction'
[Blizzard_Menu/Menu.lua]:922: in function 'Pick'
[Blizzard_Menu/MenuTemplates.lua]:80: in function <Blizzard_Menu/MenuTemplates.lua:74>


Locals:
self=ChatFrame1EditBox <FloatingChatFrame.xml:564>{
 BottomLeftCorner=Texture <NineSlice.lua:52>
 RightEdge=Texture <NineSlice.lua:52>
 disallowAutoComplete=false
 prompt=ChatFrame1EditBoxPrompt <ChatFrameEditBox.xml:59>
 glossTex=true
 characterCount=FontString <Chat.lua:995>
 PixelSnapDisabled=true
 _WIM_WhisperEngine_Hooked=true
 TopEdge=Texture <NineSlice.lua:52>
 LeftEdge=Texture <NineSlice.lua:52>
 chatFrame=ChatFrame1 <FloatingChatFrame.xml:716>
 TopRightCorner=Texture <NineSlice.lua:52>
 BottomRightCorner=Texture <NineSlice.lua:52>
 headerSuffix=ChatFrame1EditBoxHeaderSuffix <ChatFrameEditBox.xml:54>
 text="/cw Fadeski-Westfall "
 chatStyle="classic"
 template="Default"
 tabCompleteTableIndex=1
 BottomEdge=Texture <NineSlice.lua:52>
 setText=0
 historyLines=<table>
 TopLeftCorner=Texture <NineSlice.lua:52>
 historyIndex=0
 autoCompleteParams=<table>
 backdropInfo=<table>
 header=ChatFrame1EditBoxHeader <ChatFrameEditBox.xml:48>
 addHighlightedText=true
 Center=Texture <NineSlice.lua:52>
 addSpaceToAutoComplete=true
}
internalCall=nil
chatType="WHISPER"
tellTarget=nil
prevChatType="WHISPER"
prevTellTarget=nil
_G=<table>{
 ERR_OUT_OF_CHI="Not enough chi"
 DH_HAVOC_CORE_ABILITY_2="Strong melee attack that consumes Fury. If it critical strikes, some Fury is refunded."
 QuestieFrame1464=QuestieFrame1464 <ThreadLib.lua:37>
 UNIT_NAMES_COMBATLOG_TOOLTIP="Color unit names."
 LE_GAME_ERR_CHAT_RAID_RESTRICTED_TRIAL=809
 SPELL_FAILED_CUSTOM_ERROR_71="This partygoer wants to dance with you."
 ElvUF_Raid2Group8UnitButton3_PowerBar=ElvUF_Raid2Group8UnitButton3_PowerBar <Power.lua:64>
 InspectFrameTab1HighlightTexture=InspectFrameTab1HighlightTexture <CharacterFrameTemplates.xml:114>
 ContainerFrame3Item34SubIconTexture=ContainerFrame3Item34SubIconTexture <ItemButtonTemplate.xml:52>
 questieLineFrame941=questieLineFrame941 <ThreadLib.lua:37>
 MultiBarLeftButton7=MultiBarLeftButton7 <ActionBar.lua:31>
 LE_GAME_ERR_INVALID_FOLLOW_PVP_COMBAT=376
 MerchantItem6AltCurrencyFrameItem1Text=MerchantItem6AltCurrencyFrameItem1Text <MoneyFrame.xml:338>
 MacroToolkitButton284Name=MacroToolkitButton284Name <MacroToolkit.xml:14>
 OPTION_SHOW_ACTION_BAR5_TOOLTIP="Attached to the left side of Action Bar 4 by default"
 BINDING_NAME_NAMEPLATES="Show Enemy Name Plates"
 INSTANCE_UNAVAILABLE_OTHER_TEMPORARILY_DISABLED="%s cannot enter. This instance is temporarily disabled."
 WIM3_msgFrame4Backdrop=WIM3_msgFrame4Backdrop <WindowHandler.lua:871>
 WhatsTrainingFrameRow3Spell=WhatsTrainingFrameRow3Spell <WhatsTrainingUI.lua:259>
 DUNGEON_FLOOR_UPPERBLACKROCKSPIRE3="Hall of Blackhand"
 CraftExpandTabLeft=CraftExpandTabLeft <Blizzard_CraftUI.xml:284>
 CinematicFrameRaidBossEmoteFrame=CinematicFrameRaidBossEmoteFrame <CinematicFrame.xml:25>
 CompactRaidFrameManagerDisplayFrameHiddenModeToggleTopRight=CompactRaidFrameManagerDisplayFrameHiddenModeToggleTopRight <SharedUIPanelTemplates.xml:834>
 LE_GAME_ERR_ONLY_ONE_QUIVER=33
 SpellButton6Cooldown=SpellButton6Cooldown <SpellBookFrame.xml:111>
 PallyPowerBlessingsFramePlayer13Line5=PallyPowerBlessingsFramePlayer13Line5 <PallyPower_Vanilla.xml:1152>
 LOSS_OF_CONTROL_DISPLAY_FEAR="Feared"
 MacroFrame=MacroFrame <Blizzard_MacroUI.xml:23>
 LibDBIcon10_BugSack=LibDBIcon10_BugSack <LibDBIcon-1.0.lua:252>
 ElvUI_Bar6Button6=ElvUI_Bar6Button6 <LibActionButton-1.0.lua:287>
 linePool8=linePool8 <ThreadLib.lua:37>
 ACTION_SPELL_MISSED_POSSESSIVE="1"
 RaidUtility_CloseButton=RaidUtility_CloseButton <RaidUtility.lua:223>
 ARKINV_Frame4TitleActionButton2=ARKINV_Frame4TitleActionButton2 <ArkInventory.xml:1373>
 QuestieFrame776Glow=QuestieFrame776Glow <ThreadLib.lua:37>
 CompactRaidFrameManagerDisplayFrameFilterOptionsFilterRoleTankMiddleMiddle=CompactRaidFrameManagerDisplayFrameFilterOptionsFilterRoleTankMiddleMiddle <SharedUIPanelTemplates.xml:887>
 ContainerFrame4Item16Cooldown=ContainerFrame4Item16Cooldown <ContainerFrame.xml:160>
 DUNGEON_FLOOR_DRAGONBLIGHTCHROMIESCENARIO2="Andorhal"
 ElvUF_Raid1Group5UnitButton3_HealthBar_AbsorbHealBar=ElvUF_Raid1Group5UnitButton3_HealthBar_AbsorbHealBar <HealPrediction.lua:45>
 WowT