### PR TITLE
Enhance ShortcutBar button handling

### DIFF
--- a/Modules/ShortcutBar.lua
+++ b/Modules/ShortcutBar.lua
@@ -162,6 +162,7 @@ local function createShortCutBar(win)
 			end
 			for i=1,#buttons do
 				self.buttons[i].index = i;
+				self.buttons[i].parentWindow = self.parentWindow;
 				self.buttons[i]:SetNormalTexture(skin.buttons.NormalTexture);
 				self.buttons[i]:SetPushedTexture(skin.buttons.PushedTexture);
 				self.buttons[i]:SetHighlightTexture(skin.buttons.HighlightTexture, skin.buttons.HighlightAlphaMode);
@@ -303,14 +304,17 @@ function ShortcutBar:FRIENDLIST_UPDATE()
 			friend = i;
 		end
 	end
+	if(not friend) then
+		return;
+	end
 	for widget in Widgets("shortcuts") do
-		if(lists.friends[widget.parentWindow.theUser] or _G.UnitName("player") == widget.parentWindow.theUser) then
-			if(friend) then
-				widget.buttons[friend]:Disable();
-			end
-		else
-			if(friend) then
-				widget.buttons[friend]:Enable();
+		-- friend index is from the whisper button table; other window types (chat) have their own button sets.
+		local button = widget.type == "whisper" and widget.buttons[friend];
+		if(button and widget.parentWindow) then
+			if(lists.friends[widget.parentWindow.theUser] or _G.UnitName("player") == widget.parentWindow.theUser) then
+				button:Disable();
+			else
+				button:Enable();
 			end
 		end
 	end


### PR DESCRIPTION
Add parentWindow property to buttons and update friend button logic.

Getting some lua errors in Classic Era.

1x WIM/Modules/ShortcutBar.lua:371: attempt to index field 'parentWindow' (a nil value)
[WIM/Modules/ShortcutBar.lua]:371: in function 'OnEnter'
[WIM/Modules/ShortcutBar.lua]:49: in function <WIM/Modules/ShortcutBar.lua:45>


Locals:
self=WIM_ShortcutBarButton1 <[ShortcutBar.lua:31](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>{
 index=1
 isEnabled=true
 PixelSnapDisabled=true
 icon=Texture <[ShortcutBar.lua:32](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
}
(*temporary)=nil
(*temporary)=nil
(*temporary)=nil
(*temporary)=nil
(*temporary)=nil
(*temporary)=nil
(*temporary)=nil
(*temporary)=nil
(*temporary)=nil
(*temporary)=nil
(*temporary)="attempt to index field 'parentWindow' (a nil value)"
_G=<table>{
 ERR_OUT_OF_CHI="Not enough chi"
 DH_HAVOC_CORE_ABILITY_2="Strong melee attack that consumes Fury. If it critical strikes, some Fury is refunded."
 QuestieFrame1464=QuestieFrame1464 <[ThreadLib.lua:37](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 UNIT_NAMES_COMBATLOG_TOOLTIP="Color unit names."
 LE_GAME_ERR_CHAT_RAID_RESTRICTED_TRIAL=809
 SPELL_FAILED_CUSTOM_ERROR_71="This partygoer wants to dance with you."
 ElvUF_Raid2Group8UnitButton3_PowerBar=ElvUF_Raid2Group8UnitButton3_PowerBar <[Power.lua:64](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 ContainerFrame3Item34SubIconTexture=ContainerFrame3Item34SubIconTexture <[ItemButtonTemplate.xml:52](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 MultiBarLeftButton7=MultiBarLeftButton7 <[ActionBar.lua:31](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 LE_GAME_ERR_INVALID_FOLLOW_PVP_COMBAT=376
 MerchantItem2AltCurrencyFrameItem1Text=MerchantItem2AltCurrencyFrameItem1Text <[MoneyFrame.xml:338](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 MacroToolkitButton284Name=MacroToolkitButton284Name <[MacroToolkit.xml:14](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 OPTION_SHOW_ACTION_BAR5_TOOLTIP="Attached to the left side of Action Bar 4 by default"
 BINDING_NAME_NAMEPLATES="Show Enemy Name Plates"
 INSTANCE_UNAVAILABLE_OTHER_TEMPORARILY_DISABLED="%s cannot enter. This instance is temporarily disabled."
 WhatsTrainingFrameRow3Spell=WhatsTrainingFrameRow3Spell <[WhatsTrainingUI.lua:259](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 ERR_NOAMMO_S="%s"
 CraftExpandTabLeft=CraftExpandTabLeft <Blizzard_CraftUI.xml:284>
 CinematicFrameRaidBossEmoteFrame=CinematicFrameRaidBossEmoteFrame <[CinematicFrame.xml:25](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 CompactRaidFrameManagerDisplayFrameHiddenModeToggleTopRight=CompactRaidFrameManagerDisplayFrameHiddenModeToggleTopRight <[SharedUIPanelTemplates.xml:834](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 LE_GAME_ERR_ONLY_ONE_QUIVER=33
 PallyPowerBlessingsFramePlayer13Line5=PallyPowerBlessingsFramePlayer13Line5 <PallyPower_Vanilla.xml:1152>
 LOSS_OF_CONTROL_DISPLAY_FEAR="Feared"
 MacroFrame=MacroFrame <Blizzard_MacroUI.xml:23>
 LibDBIcon10_BugSack=LibDBIcon10_BugSack <[LibDBIcon-1.0.lua:252](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 ElvUI_Bar6Button6=ElvUI_Bar6Button6 <[LibActionButton-1.0.lua:287](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 linePool8=linePool8 <[ThreadLib.lua:37](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 ACTION_SPELL_MISSED_POSSESSIVE="1"
 RaidUtility_CloseButton=RaidUtility_CloseButton <[RaidUtility.lua:223](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 ARKINV_Frame4TitleActionButton2=ARKINV_Frame4TitleActionButton2 <[ArkInventory.xml:1373](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 QuestieFrame776Glow=QuestieFrame776Glow <[QuestieFrame.lua:46](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 CompactRaidFrameManagerDisplayFrameFilterOptionsFilterRoleTankMiddleMiddle=CompactRaidFrameManagerDisplayFrameFilterOptionsFilterRoleTankMiddleMiddle <[SharedUIPanelTemplates.xml:887](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 ContainerFrame4Item16Cooldown=ContainerFrame4Item16Cooldown <[ContainerFrame.xml:160](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 DUNGEON_FLOOR_DRAGONBLIGHTCHROMIESCENARIO2="Andorhal"
 ElvUF_Raid1Group5UnitButton3_HealthBar_AbsorbHealBar=ElvUF_Raid1Group5UnitButton3_HealthBar_AbsorbHealBar <[HealPrediction.lua:45](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 WowTokenRedemptionFrameBg=WowTokenRedemptionFrameBg <[SharedUIPanelTemplates.xml:1279](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 SPELL_FAILED_CUSTOM_ERROR_152="You must choose a specialization to use Ascendance."
 LAG_TOLERANCE="Lag Tolerance"
 PallyPowerC9P1Rng=PallyPowerC9P1Rng <PallyPower_Vanilla.xml:303>
 MacroToolkitButton29Unbound=MacroToolkitButton29Unbound <[MacroToolkit.xml:6](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 ElvUI_Bar5Button9NormalTexture=ElvUI_Bar5Button9NormalTexture <[ActionButtonTemplate.xml:140](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 TUTORIAL61_SPELLID_DRUID="768"
 L_DropDownListQuestie2=L_DropDownListQuestie2 <[LibUIDropDownMenu.lua:498](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 LE_GAME_ERR_NOT_ON_TOURNAMENT_REALM=912
 UIWidgetCenterDisplayFrameText=UIWidgetCenterDisplayFrameText <[SecureUIPanelTemplates.xml:252](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 PlayerTalentFrameBranch17=PlayerTalentFrameBranch17 <Blizzard_TalentUI.xml:359>
 OPTION_TOOLTIP_SHOW_ACCOUNT_ACHIEVEMENTS="Turning this option on will only display your character achievements when people inspect you or use the Blizzard website or mobile app."
 SPIRIT_HEALER_RELEASE_RED="|cffff2020Spirit Healer|r"
 OPTION_TOOLTIP_FIX_LAG="Enabling this reduces user interface lag, but may drastically reduce frame

18x WIM/Modules/ShortcutBar.lua:313: attempt to index field '?' (a nil value)
[WIM/Modules/ShortcutBar.lua]:313: in function 'FRIENDLIST_UPDATE'
[WIM/Modules/ShortcutBar.lua]:422: in function 'SetDefaults'
[WIM/Modules/ShortcutBar.lua]:76: in function 'SetDefaults'
[WIM/Modules/ShortcutBar.lua]:200: in function 'SetDefaults'
[WIM/Sources/WindowHandler.lua]:797: in function <WIM/Sources/WindowHandler.lua:774>
[WIM/Sources/WindowHandler.lua]:1440: in function <WIM/Sources/WindowHandler.lua:834>
[WIM/Sources/WindowHandler.lua]:1584: in function <WIM/Sources/WindowHandler.lua:1531>
[tail call]: ?
[WIM/Modules/WhisperEngine.lua]:275: in function <WIM/Modules/WhisperEngine.lua:236>
[WIM/Modules/WhisperEngine.lua]:862: in function <WIM/Modules/WhisperEngine.lua:834>
[C]: in function 'UpdateHeader'
[Blizzard_ChatFrameBase/Shared/ChatFrameEditBox.lua]:151: in function <...s/Blizzard_ChatFrameBase/Shared/ChatFrameEditBox.lua:135>
[C]: in function 'ProcessChatType'
[Blizzard_ChatFrameBase/Shared/ChatFrameEditBox.lua]:198: in function 'HandleChatType'
[Blizzard_ChatFrameBase/Shared/ChatFrameEditBox.lua]:248: in function 'ParseText'
[Blizzard_ChatFrameBase/Shared/ChatFrameEditBox.lua]:515: in function <...s/Blizzard_ChatFrameBase/Shared/ChatFrameEditBox.lua:514>
[C]: in function 'SetText'
[Blizzard_ChatFrameBase/Shared/ChatFrameEditBox.lua]:360: in function <...s/Blizzard_ChatFrameBase/Shared/ChatFrameEditBox.lua:358>


Locals:
self=<table>{
 db_defaults=<table>
 enableByDefault=true
 db=<table>
 resources=<table>
 enabled=true
 title="ShortcutBar"
 canDisable=true
 hasWidget=false
}
buttons=<table>{
 1=<table>
 2=<table>
 3=<table>
 4=<table>
}
friend=3
(for state)=nil
(for control)=Frame <[ShortcutBar.lua:89](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>{
 parentWindow=WIM3_msgFrame1 <[WindowHandler.lua:1573](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 visibleCount=0
 widgetName="shortcuts"
 type="chat"
 buttons=<table>
 enabled=true
}
widget=Frame <[ShortcutBar.lua:89](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>{
 parentWindow=WIM3_msgFrame1 <[WindowHandler.lua:1573](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 visibleCount=0
 widgetName="shortcuts"
 type="chat"
 buttons=<table>
 enabled=true
}
(*temporary)=nil
(*temporary)=nil
(*temporary)="attempt to index field '?' (a nil value)"
_G=<table>{
 ERR_OUT_OF_CHI="Not enough chi"
 DH_HAVOC_CORE_ABILITY_2="Strong melee attack that consumes Fury. If it critical strikes, some Fury is refunded."
 QuestieFrame1464=QuestieFrame1464 <[ThreadLib.lua:37](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 UNIT_NAMES_COMBATLOG_TOOLTIP="Color unit names."
 LE_GAME_ERR_CHAT_RAID_RESTRICTED_TRIAL=809
 SPELL_FAILED_CUSTOM_ERROR_71="This partygoer wants to dance with you."
 ElvUF_Raid2Group8UnitButton3_PowerBar=ElvUF_Raid2Group8UnitButton3_PowerBar <[Power.lua:64](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 ContainerFrame3Item34SubIconTexture=ContainerFrame3Item34SubIconTexture <[ItemButtonTemplate.xml:52](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 MultiBarLeftButton7=MultiBarLeftButton7 <[ActionBar.lua:31](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 LE_GAME_ERR_INVALID_FOLLOW_PVP_COMBAT=376
 MerchantItem2AltCurrencyFrameItem1Text=MerchantItem2AltCurrencyFrameItem1Text <[MoneyFrame.xml:338](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 MacroToolkitButton284Name=MacroToolkitButton284Name <[MacroToolkit.xml:14](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 OPTION_SHOW_ACTION_BAR5_TOOLTIP="Attached to the left side of Action Bar 4 by default"
 BINDING_NAME_NAMEPLATES="Show Enemy Name Plates"
 INSTANCE_UNAVAILABLE_OTHER_TEMPORARILY_DISABLED="%s cannot enter. This instance is temporarily disabled."
 WhatsTrainingFrameRow3Spell=WhatsTrainingFrameRow3Spell <[WhatsTrainingUI.lua:259](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 ERR_NOAMMO_S="%s"
 CraftExpandTabLeft=CraftExpandTabLeft <Blizzard_CraftUI.xml:284>
 CinematicFrameRaidBossEmoteFrame=CinematicFrameRaidBossEmoteFrame <[CinematicFrame.xml:25](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 CompactRaidFrameManagerDisplayFrameHiddenModeToggleTopRight=CompactRaidFrameManagerDisplayFrameHiddenModeToggleTopRight <[SharedUIPanelTemplates.xml:834](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 LE_GAME_ERR_ONLY_ONE_QUIVER=33
 PallyPowerBlessingsFramePlayer13Line5=PallyPowerBlessingsFramePlayer13Line5 <PallyPower_Vanilla.xml:1152>
 LOSS_OF_CONTROL_DISPLAY_FEAR="Feared"
 MacroFrame=MacroFrame <Blizzard_MacroUI.xml:23>
 LibDBIcon10_BugSack=LibDBIcon10_BugSack <[LibDBIcon-1.0.lua:252](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 ElvUI_Bar6Button6=ElvUI_Bar6Button6 <[LibActionButton-1.0.lua:287](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 linePool8=linePool8 <[ThreadLib.lua:37](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 ACTION_SPELL_MISSED_POSSESSIVE="1"
 RaidUtility_CloseButton=RaidUtility_CloseButton <[RaidUtility.lua:223](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 ARKINV_Frame4TitleActionButton2=ARKINV_Frame4TitleActionButton2 <[ArkInventory.xml:1373](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 QuestieFrame776Glow=QuestieFrame776Glow <[QuestieFrame.lua:46](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 CompactRaidFrameManagerDisplayFrameFilterOptionsFilterRoleTankMiddleMiddle=CompactRaidFrameManagerDisplayFrameFilterOptionsFilterRoleTankMiddleMiddle <[SharedUIPanelTemplates.xml:887](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 ContainerFrame4Item16Cooldown=ContainerFrame4Item16Cooldown <[ContainerFrame.xml:160](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 DUNGEON_FLOOR_DRAGONBLIGHTCHROMIESCENARIO2="Andorhal"
 ElvUF_Raid1Group5UnitButton3_HealthBar_AbsorbHealBar=ElvUF_Raid1Group5UnitButton3_HealthBar_AbsorbHealBar <[HealPrediction.lua:45](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 WowTokenRedemptionFrameBg=WowTokenRedemptionFrameBg <[SharedUIPanelTemplates.xml:1279](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 SPELL_FAILED_CUSTOM_ERROR_152="You must choose a specialization to use Ascendance."
 LAG_TOLERANCE="Lag Tolerance"
 PallyPowerC9P1Rng=PallyPowerC9P1Rng <PallyPower_Vanilla.xml:303>
 MacroToolkitButton29Unbound=MacroToolkitButton29Unbound <[MacroToolkit.xml:6](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 ElvUI_Bar5Button9NormalTexture=ElvUI_Bar5Button9NormalTexture <[ActionButtonTemplate.xml:140](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 TUTORIAL61_SPELLID_DRUID="768"
 L_DropDownListQuestie2=L_DropDownListQuestie2 <[LibUIDropDownMenu.lua:498](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 LE_GAME_ERR_NOT_ON_TOURNAMENT_REALM=912
 UIWidgetCenterDisplayFrameText=UIWidgetCenterDisplayFrameText <[SecureUIPanelTemplates.xml:252](https://claude.ai/epitaxy/local_76c6cbb4-739c-40f3-ae0b-97fc495bd659)>
 PlayerTalentFrameBranch17=PlayerTalentFrameBranch17 <Blizzard_TalentUI.xml:359>
 OPTION_TOOLT